### PR TITLE
Agregar tema oscuro

### DIFF
--- a/darkmode.js
+++ b/darkmode.js
@@ -3,16 +3,15 @@ let sunBtn = document.getElementById('sunBtn');
 const themeBtnIcon = document.getElementById('themeBtnIcon');
 const body = document.body;
 
-function sunButton() {
+// funciones/closures
+const sunButton = () => {
 	moonBtn.style.display = 'none';
 	sunBtn.style.display = 'block';
 }
-function moonButton() {
+const moonButton = () => {
 	sunBtn.style.display = 'none';
 	moonBtn.style.display = 'block';
 }
-
-// funciones/closures
 const makeDark = () => {
 	body.classList.replace('light', 'dark');
 	localStorage.setItem('theme', 'dark');
@@ -32,6 +31,7 @@ sunBtn.onclick = makeLight;
 
 // condiciones para que se mantenga la oscuridad mediante cache localstorage
 window.onload = () => {
-	body.classList.replace('light | dark', localStorage.getItem('theme'));
+	body.classList.replace('light', localStorage.getItem('theme'));
+	body.classList.replace('dark', localStorage.getItem('theme'));
 	localStorage.getItem('theme') === 'dark' ? sunButton() : moonButton();
 }

--- a/darkmode.js
+++ b/darkmode.js
@@ -3,14 +3,35 @@ let sunBtn = document.getElementById('sunBtn');
 const themeBtnIcon = document.getElementById('themeBtnIcon');
 const body = document.body;
 
-moonBtn.onclick = () => {
-	body.classList.replace('light', 'dark');
+function sunButton() {
 	moonBtn.style.display = 'none';
 	sunBtn.style.display = 'block';
-};
-
-sunBtn.onclick = () => {
-	body.classList.replace('dark', 'light');
+}
+function moonButton() {
 	sunBtn.style.display = 'none';
 	moonBtn.style.display = 'block';
+}
+
+// funciones/closures
+const makeDark = () => {
+	body.classList.replace('light', 'dark');
+	localStorage.setItem('theme', 'dark');
+	sunButton();
+	console.log('darkified');
 };
+const makeLight = () => {
+	body.classList.replace('dark', 'light');
+	localStorage.setItem('theme', 'light');
+	moonButton();
+	console.log('lightified');
+};
+
+// onclick events (Sí, son dos botones que se ocultan y muestran para parecer uno)
+moonBtn.onclick = makeDark;
+sunBtn.onclick = makeLight;
+
+// condiciones para que se mantenga la oscuridad mediante cache localstorage
+window.onload = () => {
+	body.classList.replace('light | dark', localStorage.getItem('theme'));
+	localStorage.getItem('theme') === 'dark' ? sunButton() : moonButton();
+}

--- a/darkmode.js
+++ b/darkmode.js
@@ -1,0 +1,16 @@
+let moonBtn = document.getElementById('moonBtn');
+let sunBtn = document.getElementById('sunBtn');
+const themeBtnIcon = document.getElementById('themeBtnIcon');
+const body = document.body;
+
+moonBtn.onclick = () => {
+	body.classList.replace('light', 'dark');
+	moonBtn.style.display = 'none';
+	sunBtn.style.display = 'block';
+};
+
+sunBtn.onclick = () => {
+	body.classList.replace('dark', 'light');
+	sunBtn.style.display = 'none';
+	moonBtn.style.display = 'block';
+};

--- a/header.js
+++ b/header.js
@@ -18,6 +18,8 @@ document.write('\
         <li><a href="index.html#overview">Contenido</a></li>\
         <li><a href="syllabus.html">Programa</a></li>\
         <li><a href="index.html#faq">FAQ</a></li>\
+	<li id="moonBtn" style="cursor: pointer;"><a><i id="themeBtnIcon" class="fas fa-moon" aria-hidden="true"></i></a></li>\
+	<li id="sunBtn" style="cursor: pointer; display: none;"><a><i id="themeBtnIcon" class="fas fa-sun" aria-hidden="true"></i></a></li>\
       </ul>\
     </div>\
   </div>\

--- a/index.html
+++ b/index.html
@@ -18,7 +18,7 @@
     <link rel="stylesheet" type="text/css" href="style.css" />
 
   </head>
-  <body>
+  <body class="light">
     
     <script src="header.js"></script>
 
@@ -153,6 +153,8 @@
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.11.1/jquery.min.js"></script>
     <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.2.0/js/bootstrap.min.js"></script>
     <script src="https://kit.fontawesome.com/a40ec64eb1.js" crossorigin="anonymous"></script>
+    <!-- Hermoso script de modo oscuro por Juan Castillo-->
+    <script src="./darkmode.js"></script>
         
   </body>
 

--- a/style.css
+++ b/style.css
@@ -2,6 +2,8 @@
   --sechi-bg: #f7f6f1;
   --h2-color: #8DB33A;
   --qq-color: #060;
+  --border: 1px solid #ddd;
+  --border-color: #ddd;
 }
 
 .dark {
@@ -11,6 +13,8 @@
   --h2-color: #B5C78C;
   --qq-color: #5B8055;
   --qa-color: #939986;
+  --border: 1px solid #323a21;
+  --border-color: #323a21;
 }
 
 body {
@@ -102,6 +106,7 @@ h3 {
   margin-bottom: 10px;
   padding-top: 10px;
   padding-bottom: 10px;
+  color: var(--based-white);
 }
 
 .sechighlight {
@@ -146,6 +151,22 @@ h3 {
   background-color: rgb(85, 187, 85);
   overflow: visible !important;
 }
+
+th {
+  background-color: var(--sechi-bg) !important;
+}
+
+td {
+  border-top: var(--border) !important;
+}
+
+thead th {
+  border-bottom: var(--border) !important;
+}
+
+.trlock {
+    background-color: var(--sechi-bg);
+  }
 
 #convask {
   position: absolute;
@@ -209,7 +230,7 @@ ul {
 
 .navbar-default {
   background-color: #8DB33A;
-  border-color: rgb(255, 255, 255);
+  border-color: var(--border-color);
   text-align: center;
 }
 

--- a/style.css
+++ b/style.css
@@ -164,6 +164,7 @@ thead th {
   border-bottom: var(--border) !important;
 }
 
+/* Tema para las filas de bloqueadas del syllabus*/
 .trlock {
     background-color: var(--sechi-bg);
   }

--- a/style.css
+++ b/style.css
@@ -1,8 +1,25 @@
+.light {
+  --sechi-bg: #f7f6f1;
+  --h2-color: #8DB33A;
+  --qq-color: #060;
+}
+
+.dark {
+  --body-bg: #20231B;
+  --sechi-bg: #2C331E;
+  --based-white: #E6E6E6;
+  --h2-color: #B5C78C;
+  --qq-color: #5B8055;
+  --qa-color: #939986;
+}
+
 body {
   font-family: 'Roboto', sans-serif;
   font-weight: 300;
   font-size: 16px;
   padding-top: 70px;
+  /* variables change depending on if body has light or dark class */
+  background-color: var(--body-bg);
 }
 
 p {
@@ -12,6 +29,8 @@ p {
 #header {
   margin-top: 20px;
   margin-bottom: 20px;
+  /* variable changes depending on if body has light or dark class */
+  color: var(--based-white);
 }
 
 h1 {
@@ -24,7 +43,8 @@ h2 {
   font-size: 25px;
   /* font-weight: 300; */
   font-weight: bold;
-  color: #8DB33A;
+  /* variable changes depending on if body has light or dark class */
+  color: var(--h2-color);
 }
 
 h3 {
@@ -85,7 +105,10 @@ h3 {
 }
 
 .sechighlight {
-  background-color: #f7f6f1;
+/* variables change depending on if body has light or dark class */
+  background-color: var(--sechi-bg);
+  color: var(--based-white);
+
 }
 
 .tt {
@@ -142,11 +165,14 @@ h3 {
 }
 
 .qq {
-  color: #060;
+  /* variable changes depending on if body has light or dark class */
+  color: var(--qq-color);
 }
 
 .qa {
   font-style: italic;
+  /* variable changes depending on if body has light or dark class */
+  color: var(--qa-color);
 }
 
 .qqa {

--- a/syllabus.html
+++ b/syllabus.html
@@ -18,7 +18,7 @@
     <link rel="stylesheet" type="text/css" href="style.css" />
 
   </head>
-  <body>
+  <body class="light" onload="loadTheme()">
 
     <script src="header.js"></script>
 
@@ -94,7 +94,7 @@
               Examen 1
             </td>
           </tr>
-          <tr style="background-color: #F7F6F1;">
+          <tr class="trlock">
             <td>6</td>
             <td rowspan="2">
               Introducción a las bases de datos NoSQL<br />
@@ -107,10 +107,10 @@
               Taller 3
             </td>
           </tr>
-          <tr style="background-color: #F7F6F1;">
+          <tr class="trlock">
             <td>7</td>
           </tr>
-          <tr  style="background-color: #F7F6F1;">
+          <tr class="trlock">
             <td>8</td>
             <td rowspan="2">
               Bases de datos columnares
@@ -121,13 +121,13 @@
               Taller 4
             </td>
           </tr>
-          <tr style="background-color: #F7F6F1;">
+          <tr class="trlock">
             <td>9</td>
           </tr>
           <tr>
             <td colspan="4" style="text-align: center;"><em>Semana santa</em></td>
           </tr>
-          <tr style="background-color: #F7F6F1;">
+          <tr class="trlock">
             <td>10</td>
             <td></td>
             <td></td>
@@ -172,7 +172,7 @@
           <tr>
             <td>16</td>
           </tr>
-          <tr style="background-color: #F7F6F1;">
+          <tr class="trlock">
             <td>17</td>
             <td>
             </td>
@@ -201,6 +201,8 @@
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.11.1/jquery.min.js"></script>
     <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.2.0/js/bootstrap.min.js"></script>
     <script src="https://kit.fontawesome.com/a40ec64eb1.js" crossorigin="anonymous"></script>
+    <!-- Hermoso script de modo oscuro por Juan Castillo-->
+    <script src="./darkmode.js"></script>
   
   </body>
 </html>

--- a/syllabus.html
+++ b/syllabus.html
@@ -94,6 +94,7 @@
               Examen 1
             </td>
           </tr>
+	  <!--trlock es la clase para las filas bloqueadas-->
           <tr class="trlock">
             <td>6</td>
             <td rowspan="2">


### PR DESCRIPTION
Agregué el archivo 'darkmode.js' en el cual está la funcionalidad del modo oscuro. Creo que pude haber implementado cosas de jQuery pero sinceramente no sé usarlo. XD Y me pareció buen ejercicio hacer todo vainilla, especialmente porque me forcé a implementar todo de manera funcional (Mediante el uso de closures).

Me metí con el javascript del header para adicionar el botón que cambia entre los temas oscuro y claro. En verdad son dos botones que se esconden y aparecen dependiendo del tema, pues no me funcionaba cambiar el ícono de Fontawesome de un solo botón y por rapidez lo implementé así.

Finalmente **-Y PROBABLEMENTE LO MÁS IMPORTANTE-** ahora las filas del syllabus que están "bloqueadas" (Se veían un tris más oscuras) ya no implementan el atributo de `style=""` en el html para cambiar su color, sino que utilizan la clase css `trlock` que permite la interoperabilidad con el tema oscuro (En el tema oscuro son más claras que el fondo, que es casi negro).