### PR TITLE
🪡 FIX: Modo oscuro funciona sin refrescar + Estilo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,3 @@
 Página oficial del curso de Bases de Datos 2 de la Universidad El Bosque.
+
+Ahora con Modo Oscuro! Por [Juan Castillo](https://github.com/cfuendesign)

--- a/darkmode.js
+++ b/darkmode.js
@@ -1,37 +1,39 @@
-let moonBtn = document.getElementById('moonBtn');
-let sunBtn = document.getElementById('sunBtn');
-const themeBtnIcon = document.getElementById('themeBtnIcon');
+// variables
+let moonBtn = document.getElementById("moonBtn");
+let sunBtn = document.getElementById("sunBtn");
+const themeBtnIcon = document.getElementById("themeBtnIcon");
 const body = document.body;
 
-// funciones/closures
+// funciones
 const sunButton = () => {
-	moonBtn.style.display = 'none';
-	sunBtn.style.display = 'block';
-}
+  moonBtn.style.display = "none";
+  sunBtn.style.display = "block";
+};
 const moonButton = () => {
-	sunBtn.style.display = 'none';
-	moonBtn.style.display = 'block';
-}
+  sunBtn.style.display = "none";
+  moonBtn.style.display = "block";
+};
 const makeDark = () => {
-	body.classList.replace('light', 'dark');
-	localStorage.setItem('theme', 'dark');
-	sunButton();
-	console.log('darkified');
+  body.classList.replace("light", "dark");
+  localStorage.setItem("theme", "dark");
+  sunButton();
+  console.log("darkified");
 };
 const makeLight = () => {
-	body.classList.replace('dark', 'light');
-	localStorage.setItem('theme', 'light');
-	moonButton();
-	console.log('lightified');
+  body.classList.replace("dark", "light");
+  localStorage.setItem("theme", "light");
+  moonButton();
+  console.log("lightified");
 };
 
-// onclick events (Sí, son dos botones que se ocultan y muestran para parecer uno)
+// onclick events del botón (Sí, son dos botones que se ocultan y muestran para parecer uno)
 moonBtn.onclick = makeDark;
 sunBtn.onclick = makeLight;
 
 // condiciones para que se mantenga la oscuridad mediante cache localstorage
 window.onload = () => {
-	body.classList.replace('light', localStorage.getItem('theme'));
-	body.classList.replace('dark', localStorage.getItem('theme'));
-	localStorage.getItem('theme') === 'dark' ? sunButton() : moonButton();
-}
+  localStorage.getItem("theme") || localStorage.setItem("theme", "light")
+  body.classList.replace("light", localStorage.getItem("theme"));
+  body.classList.replace("dark", localStorage.getItem("theme"));
+  localStorage.getItem("theme") === "dark" ? sunButton() : moonButton();
+};


### PR DESCRIPTION
Jeje, me puse a revisar y me dí cuenta de que el error era que cuando cargaba la página por primera vez, hasta que no se presionaba el botón para cambiar el tema, no se creaba en LocalStorage la propiedad 'theme'. Ya quedó arreglado.

También cambié un poco el estilo de darkmode.js automágicamente con [Prettier](https://prettier.io/), pero eso no importa mucho.